### PR TITLE
compile the migrate binary using cgo in the docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
+.git
+.github
 flake.*
 **.md
-.github
 **.example

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,21 @@
-FROM --platform=$BUILDPLATFORM golang:1.21 AS build
+FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.3.0 AS cross-compile
+FROM --platform=$BUILDPLATFORM golang:1.21-alpine AS build
 
-WORKDIR /go/src/app
+RUN apk add --update clang lld
 ARG TARGETOS
 ARG TARGETARCH
-ENV CGO_ENABLED=0 \
-  GOOS=${TARGETOS} \
-  GOARCH=${TARGETARCH} \
+ARG TARGETPLATFORM
+
+COPY --from=cross-compile / /
+WORKDIR /go/src/app
+ENV CGO_ENABLED=1 \
   GOCACHE=/cache/go \
   GOMODCACHE=/cache/gomod
 
 RUN <<-EOF
   go env -w GOCACHE=${GOCACHE}
   go env -w GOMODCACHE=${GOMODCACHE}
+  xx-apk add --update musl-dev gcc
 EOF
 
 RUN --mount=type=bind,source=go.mod,target=/go/src/app/go.mod,readonly \
@@ -19,13 +23,14 @@ RUN --mount=type=bind,source=go.mod,target=/go/src/app/go.mod,readonly \
   --mount=type=cache,target=${GOCACHE} \
   --mount=type=cache,target=${GOMODCACHE} \
   --mount=type=cache,target=/go/pkg \
-  go mod download -x
+  xx-go mod download -x
 
 RUN --mount=type=bind,source=.,target=/go/src/app,readonly \
   --mount=type=cache,target=${GOCACHE} \
   --mount=type=cache,target=${GOMODCACHE} \
   --mount=type=cache,target=/go/pkg \
-  go build -x -a -ldflags="-w -s" -trimpath -o /go/bin/app ./cmd/migrate
+  xx-go build -a --ldflags="-linkmode=external -extldflags='-static'" -trimpath -o /go/bin/app ./cmd/migrate \
+  && xx-verify --static /go/bin/app
 
 FROM alpine:3.18 AS main
 RUN apk add --no-cache ca-certificates


### PR DESCRIPTION
Story details: https://app.shortcut.com/gladly/story/170538

## What

- use cgo when compiling the migrate image as some of the underlying db libraries require it

## Notes

- I am using [tonistiigi/xx](https://github.com/tonistiigi/xx) to support cross compilation using cgo
- That project is supported by docker contributors and provides wrappers for automatically figuring out and setting cross-compilation flags and environment variables

## Testing

- Build the image and run simple migrations against a sqlite database

```sh
sqlite3 test.db
docker buildx build -t local/migrate --platform linux/amd64,linux/arm64 .
docker run --rm -v test.db:/workspace/test.db -w /workspace local/migrate -t=sqlite
```