### PR TITLE
ensure file permissions on certificate key is secure

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -6,6 +6,7 @@ fi
 
 if test -n "$DATABASE_CLIENT_KEY_B64"; then
   echo "$DATABASE_CLIENT_KEY_B64" | base64 -d >/tmp/client-key.pem
+  chmod 0600 /tmp/client-key.pem
 fi
 
 if test -n "$DATABASE_SERVER_CA_B64"; then


### PR DESCRIPTION
Story details: https://app.shortcut.com/gladly/story/171345

## What

- Set the file permission bits on the private client key to `0600`

## Why

```
create meta table: create meta table: pq: Private key file has group or world access. Permissions should be u=rw (0600) or less
```

- migrate requires the private key to be only user readable

## Testing

- no manual testing required